### PR TITLE
Add a 64x64 (1/32 scan) example

### DIFF
--- a/examples/simpletest_addr_e.py
+++ b/examples/simpletest_addr_e.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+"""
+Display a static 64x64 image
+
+This assumes two 64x32 matrix panels are hooked together in the "serpentine" configuration.
+
+Run like this:
+
+$ python simpletest.py
+
+The image is displayed until the user hits enter to exit.
+"""
+
+import pathlib
+
+import adafruit_raspberry_pi5_piomatter
+import numpy as np
+import PIL.Image as Image
+
+geometry = adafruit_raspberry_pi5_piomatter.Geometry(width=64, height=64, n_addr_lines=5, rotation=adafruit_raspberry_pi5_piomatter.Orientation.Normal, n_planes=7)
+framebuffer = np.asarray(Image.open(pathlib.Path(__file__).parent / "blinka64x64.png"))
+matrix = adafruit_raspberry_pi5_piomatter.AdafruitMatrixBonnetRGB888Packed(framebuffer, geometry)
+matrix.show()
+
+input("Hit enter to exit")


### PR DESCRIPTION
This shows up wrong on my panels (http://adafru.it/5362) because it also needs R/B color swapping (https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/issues/12) but it does show up!