### PR TITLE
Actually report errors in pio_sm_xfer_data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.4...3.18)
+project("_piomatter")
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
+
+find_package(pybind11 CONFIG)
+pybind11_add_module("_piomatter"
+    src/pymain.cpp src/piolib/pio_rp1.c src/piolib/piolib.c)
+target_include_directories("_piomatter" PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/src/include
+    ${CMAKE_CURRENT_LIST_DIR}/src/piolib/include)
+set_property(TARGET "_piomatter" PROPERTY
+    CXX_STANDARD 20)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "setuptools>=42",
     "pybind11>=2.10.0",
     "setuptools_scm[toml]>=6.2",
+    "cmake>=3.12"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,71 @@
 # Available at setup time due to pyproject.toml
-from pybind11.setup_helpers import Pybind11Extension, build_ext
-from setuptools import setup
+import multiprocessing
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
 from setuptools_scm import get_version
 
 __version__ = get_version()
+
+# A CMakeExtension needs a sourcedir instead of a file list.
+# The name must be the _single_ output extension from the CMake build.
+# If you need multiple extensions, see scikit-build.
+class CMakeExtension(Extension):
+    def __init__(self, name: str, sourcedir: str = "") -> None:
+        super().__init__(name, sources=[])
+        self.sourcedir = os.fspath(Path(sourcedir).resolve())
+
+
+class CMakeBuild(build_ext):
+    def build_extension(self, ext: CMakeExtension) -> None:
+        # Must be in this form due to bug in .resolve() only fixed in Python 3.10+
+        ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)
+        extdir = ext_fullpath.parent.resolve()
+
+        # Using this requires trailing slash for auto-detection & inclusion of
+        # auxiliary "native" libs
+
+        debug = int(os.environ.get("DEBUG", 0)) if self.debug is None else self.debug
+        cfg = "Debug" if debug else "Release"
+
+        # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
+        # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
+        # from Python.
+        cmake_args = [
+            "-GUnix Makefiles",
+            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
+            f"-DPYTHON_EXECUTABLE={sys.executable}",
+            f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
+        ]
+        build_args = []
+        # Adding CMake arguments set as environment variable
+        # (needed e.g. to build for ARM OSx on conda-forge)
+        if "CMAKE_ARGS" in os.environ:
+            cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
+
+        build_args += [f"-j{multiprocessing.cpu_count()}"]
+
+        build_temp = Path(self.build_temp) / ext.name
+        if not build_temp.exists():
+            build_temp.mkdir(parents=True)
+
+        subprocess.run(
+            ["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True
+        )
+        subprocess.run(
+            ["make", *build_args], cwd=build_temp, check=True
+        )
+
+
 
 # The main interface is through Pybind11Extension.
 # * You can add cxx_std=11/14/17, and then build_ext can be removed.
 # * You can set include_pybind11=false to add the include directory yourself,
 #   say from a submodule.
-
-ext_modules = [
-    Pybind11Extension("adafruit_blinka_raspberry_pi5_piomatter._piomatter",
-        ["src/pymain.cpp", "src/piolib/piolib.c", "src/piolib/pio_rp1.c"],
-        define_macros = [('VERSION_INFO', __version__)],
-        include_dirs = ['./src/include', './src/piolib/include'],
-        cxx_std=20,
-        # use this setting when debugging
-        extra_compile_args = ["-g3", "-Og"],
-        ),
-]
 
 setup(
     name="Adafruit-Blinka-Raspberry-Pi5-Piomatter",
@@ -27,10 +73,8 @@ setup(
     url="https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter",
     description="HUB75 matrix driver for Raspberry Pi 5 using PIO",
     long_description="A pio-based driver",
-    ext_modules=ext_modules,
-    # Currently, build_ext only provides an optional "highest supported C++
-    # level" feature, but in the future it may provide more features.
-    cmdclass={"build_ext": build_ext},
+    ext_modules=[CMakeExtension("adafruit_blinka_raspberry_pi5_piomatter._piomatter")],
+    cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
     python_requires=">=3.11",
     packages=['adafruit_blinka_raspberry_pi5_piomatter'],

--- a/src/include/piomatter/piomatter.h
+++ b/src/include/piomatter/piomatter.h
@@ -26,7 +26,7 @@ struct piomatter_base {
     piomatter_base &operator=(const piomatter_base &) = delete;
 
     virtual ~piomatter_base() {}
-    virtual void show() = 0;
+    virtual int show() = 0;
 
     double fps;
 };
@@ -48,7 +48,11 @@ struct piomatter : piomatter_base {
         show();
     }
 
-    void show() override {
+    int show() override {
+        int err = pending_error_errno.exchange(0); // we're handling this error
+        if (err != 0) {
+            return err;
+        }
         int buffer_idx = manager.get_free_buffer();
         auto &bufseq = buffers[buffer_idx];
         bufseq.resize(geometry.schedules.size());
@@ -61,6 +65,7 @@ struct piomatter : piomatter_base {
             old_active_time = geometry.schedules[i].back().active_time;
         }
         manager.put_filled_buffer(buffer_idx);
+        return 0;
     }
 
     ~piomatter() {
@@ -174,7 +179,15 @@ struct piomatter : piomatter_base {
                 const auto &data = cur_buf[seq_idx];
                 auto datasize = sizeof(uint32_t) * data.size();
                 auto dataptr = const_cast<uint32_t *>(&data[0]);
-                pio_sm_xfer_data(pio, sm, PIO_DIR_TO_SM, datasize, dataptr);
+                // returns err = rp1_ioctl.... which seems to be a negative
+                // errno value
+                int r =
+                    pio_sm_xfer_data(pio, sm, PIO_DIR_TO_SM, datasize, dataptr);
+                if (r != 0) {
+                    pending_error_errno.store(-r);
+                    printf("xfer_data() returned error %d (%s)\n", r,
+                           strerror(-r));
+                }
                 t1 = monotonicns64();
                 if (t0 != t1) {
                     fps = 1e9 / (t1 - t0);
@@ -194,6 +207,7 @@ struct piomatter : piomatter_base {
     matrix_geometry geometry;
     colorspace converter;
     std::thread blitter_thread;
+    std::atomic<int> pending_error_errno;
 };
 
 } // namespace piomatter

--- a/src/pymain.cpp
+++ b/src/pymain.cpp
@@ -18,7 +18,14 @@ struct PyPiomatter {
     py::buffer buffer;
     std::unique_ptr<piomatter::piomatter_base> matter;
 
-    void show() { matter->show(); }
+    void show() {
+        int err = matter->show();
+        if (err != 0) {
+            errno = err;
+            PyErr_SetFromErrno(PyExc_OSError);
+            throw py::error_already_set();
+        }
+    }
     double fps() const { return matter->fps; }
 };
 


### PR DESCRIPTION
& convert to cmake, so that there's correct header dependency analysis i.e., `setup.py build` will actually rebuild if needed.